### PR TITLE
fix(machinepool): invert Status.Deprecated nil guards in failure mirror (fixes panic on infra failure)

### DIFF
--- a/internal/controllers/machinepool/machinepool_controller_phases.go
+++ b/internal/controllers/machinepool/machinepool_controller_phases.go
@@ -153,19 +153,19 @@ func (r *Reconciler) reconcileExternal(ctx context.Context, m *clusterv1.Machine
 	}
 	if failureReason != "" {
 		machineStatusFailure := capierrors.MachinePoolStatusFailure(failureReason)
-		if m.Status.Deprecated != nil {
+		if m.Status.Deprecated == nil {
 			m.Status.Deprecated = &clusterv1.MachinePoolDeprecatedStatus{}
 		}
-		if m.Status.Deprecated.V1Beta1 != nil {
+		if m.Status.Deprecated.V1Beta1 == nil {
 			m.Status.Deprecated.V1Beta1 = &clusterv1.MachinePoolV1Beta1DeprecatedStatus{}
 		}
 		m.Status.Deprecated.V1Beta1.FailureReason = &machineStatusFailure
 	}
 	if failureMessage != "" {
-		if m.Status.Deprecated != nil {
+		if m.Status.Deprecated == nil {
 			m.Status.Deprecated = &clusterv1.MachinePoolDeprecatedStatus{}
 		}
-		if m.Status.Deprecated.V1Beta1 != nil {
+		if m.Status.Deprecated.V1Beta1 == nil {
 			m.Status.Deprecated.V1Beta1 = &clusterv1.MachinePoolV1Beta1DeprecatedStatus{}
 		}
 		m.Status.Deprecated.V1Beta1.FailureMessage = ptr.To(


### PR DESCRIPTION
## Summary

Fixes a nil-pointer panic in the MachinePool controller's failure-mirror path, observed live on pcp-7201-eks when a backing `AWSManagedMachinePool` reports `status.failureMessage`.

## The bug

`reconcileExternal` mirrors the referenced infra CR's `failureReason`/`failureMessage` into `MachinePool.Status.Deprecated.V1Beta1.*` for backward compat. The lazy-init guards for the two nested pointers were **inverted**:

```go
if m.Status.Deprecated != nil {          // should be == nil
    m.Status.Deprecated = &clusterv1.MachinePoolDeprecatedStatus{}
}
if m.Status.Deprecated.V1Beta1 != nil {  // should be == nil
    m.Status.Deprecated.V1Beta1 = &clusterv1.MachinePoolV1Beta1DeprecatedStatus{}
}
m.Status.Deprecated.V1Beta1.FailureReason = &machineStatusFailure   // ← NPE
```

On a fresh MachinePool `Status.Deprecated` is nil → the `!= nil` guard skips the initializer → next line dereferences nil → panic. Same broken pattern for both `failureReason` and `failureMessage` blocks.

**controller-runtime recovers each panic** so the pod stays `1/1 Running`, but the MachinePool reconcile never completes, and this repeats every ~2 minutes.

## Why it hasn't been caught before

Both blocks are gated on `failureReason != ""` / `failureMessage != ""` — they only run when the infra provider surfaces a failure. In the happy path the code is unreachable, so the bug has been dormant in released tags and on `main`. Now hit in production when an EKS nodegroup went `CREATE_FAILED` and CAPA propagated `status.failureMessage = "EKS nodegroup in failed CREATE_FAILED status"`.

## Fix

Four polarity flips (`!= nil` → `== nil`), matching the idiom every sister controller in the same repo already uses:

- `internal/controllers/machine/machine_controller_phases.go:62-66`
- `internal/controllers/machineset/machineset_controller.go:1431-1435`
- `internal/controllers/cluster/cluster_controller_phases.go:75-88`
- `internal/controllers/machinedeployment/machinedeployment_sync.go:268-272`

Verified same broken code on **upstream kubernetes-sigs/cluster-api** — tags `v1.13.2`, `v1.13.3`, `v1.13.4` and `main` HEAD (`core/reconcilers/machinepool/machinepool_controller_phases.go`). Upstream PR to follow.

## Test plan

- [x] `go build ./...` clean
- [ ] After image build + deploy, verify `capi-controller-manager` logs stop showing "Observed a panic" on the pcp-7201-eks workload cluster once the underlying `AWSManagedMachinePool` failure is addressed OR the failure is left in place (the controller now reflects the failure into `Status.Deprecated.V1Beta1.FailureMessage` cleanly instead of panicking).

Target: `spectro-v1.13.3-master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
